### PR TITLE
fix tx manual load

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -233,7 +233,7 @@ export class JungleBusClient {
           if(!tx.transaction.length && !liteMode) {
             const url = `${this.client.useSSL ? 'https' : 'http'}://${this.client.serverUrl}/v1/transaction/get/${tx.id}/bin`;
             const resp = await fetch(url);
-            tx.transaction = Buffer.from(await resp.arrayBuffer()).toString('base64')
+            tx.transaction = Buffer.from(await resp.arrayBuffer()).toString('hex')
           }
           onPublish(tx);
         }
@@ -245,7 +245,7 @@ export class JungleBusClient {
           if(!tx.transaction.length && !liteMode) {
             const url = `${this.client.useSSL ? 'https' : 'http'}://${this.client.serverUrl}/v1/transaction/get/${tx.id}/bin`;
             const resp = await fetch(url);
-            tx.transaction = Buffer.from(await resp.arrayBuffer()).toString('base64')
+            tx.transaction = Buffer.from(await resp.arrayBuffer()).toString('hex')
           }
           onMempool(tx);
         }


### PR DESCRIPTION
Background loading of transactions was using base64 for some reason. This has been resolved. Can we please push a new version?